### PR TITLE
Enable compatibility with Laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*",
+        "illuminate/support": "~4.1",
         "mixpanel/mixpanel-php" : "2.*"
     },
     "autoload": {


### PR DESCRIPTION
Changed the composer requirement from strict `4.1.x` to `>= 4.1 < 5.0`. I have tested that the package works with my Laravel 4.2 installation so no further changes are necessary.
